### PR TITLE
Add SLURM compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+**/data
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 **/data
+**/jobs
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,6 @@ numpy
 pandas
 requests
 scikit-learn
-scipy
+scipy>=1.1.0
 tables
 tqdm

--- a/scripts/avocado_featurize_submit
+++ b/scripts/avocado_featurize_submit
@@ -77,9 +77,9 @@ if __name__ == "__main__":
         help='Working directory. Default is the current directory.'
     )
     parser.add_argument(
-        '--schedular',
+        '--scheduler',
         default=None,
-        help='Schedular system. sge or slurm'
+        help='scheduler system. sge or slurm'
     )
     parser.add_argument(
         '--jobs_directory',
@@ -122,7 +122,7 @@ if __name__ == "__main__":
 
         job_path = '{jobs_directory}/{job_name}.sh'.format(**job_args)
 
-        if args['schedular'] is None:
+        if args['scheduler'] is None:
             job_template = sge_template.format(**job_args)
 
             # Write the jobs file

--- a/scripts/avocado_featurize_submit
+++ b/scripts/avocado_featurize_submit
@@ -110,7 +110,6 @@ if __name__ == "__main__":
         )
     os.makedirs(args['jobs_directory'], exist_ok=True)
 
-
     # Create and submit the jobs one by one
     for job_id in range(args['num_jobs']):
         job_args = args.copy()
@@ -122,7 +121,7 @@ if __name__ == "__main__":
 
         job_path = '{jobs_directory}/{job_name}.sh'.format(**job_args)
 
-        if args['scheduler'] is None:
+        if args['scheduler'] == "sge":
             job_template = sge_template.format(**job_args)
 
             # Write the jobs file
@@ -131,7 +130,7 @@ if __name__ == "__main__":
 
             # Submit the job
             subprocess.call(["qsub"] + args['extra_arguments'].split() + [job_path])
-        else:
+        elif args['scheduler'] == "slurm":
             job_template = slurm_template.format(**job_args)
 
             # Write the jobs file
@@ -140,3 +139,10 @@ if __name__ == "__main__":
 
             # Submit the job
             subprocess.call(["sbatch"] + args['extra_arguments'].split() + [job_path])
+        else:
+            msg = """
+            Invalid scheduler name provided.
+
+            Please set scheduler to either "sge" or "slurm" depending on your system
+                  """
+            raise NameError(msg)

--- a/scripts/avocado_featurize_submit
+++ b/scripts/avocado_featurize_submit
@@ -78,7 +78,7 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         '--scheduler',
-        default=None,
+        default="sge",
         help='scheduler system. sge or slurm'
     )
     parser.add_argument(

--- a/scripts/avocado_featurize_submit
+++ b/scripts/avocado_featurize_submit
@@ -33,6 +33,25 @@ avocado_featurize \\
     --tag {tag}
 """
 
+slurm_template = """#!/bin/bash
+#SBATCH --export=ALL
+#SBATCH -J {job_name}
+#SBATCH -o {jobs_directory}/{job_name}.out
+#SBATCH -e {jobs_directory}/{job_name}.err
+
+# Use a single core for each job. This parallelizes better than trying to use
+# multiple cores per job.
+export MKL_NUM_THREADS=1
+export NUMEXPR_NUM_THREADS=1
+export OMP_NUM_THREADS=1
+
+cd {working_directory}
+avocado_featurize \\
+    {dataset} \\
+    --chunk {job} \\
+    --num_chunks {num_jobs} \\
+    --tag {tag}
+"""
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
@@ -56,6 +75,11 @@ if __name__ == "__main__":
         '--working_directory',
         default=None,
         help='Working directory. Default is the current directory.'
+    )
+    parser.add_argument(
+        '--schedular',
+        default=None,
+        help='Schedular system. sge or slurm'
     )
     parser.add_argument(
         '--jobs_directory',
@@ -98,11 +122,21 @@ if __name__ == "__main__":
 
         job_path = '{jobs_directory}/{job_name}.sh'.format(**job_args)
 
-        job_template = sge_template.format(**job_args)
+        if args['schedular'] is None:
+            job_template = sge_template.format(**job_args)
 
-        # Write the jobs file
-        with open(job_path, 'w') as job_file:
-            job_file.write(job_template)
+            # Write the jobs file
+            with open(job_path, 'w') as job_file:
+                job_file.write(job_template)
 
-        # Submit the job
-        subprocess.call(["qsub"] + args['qsub_arguments'].split() + [job_path])
+            # Submit the job
+            subprocess.call(["qsub"] + args['qsub_arguments'].split() + [job_path])
+        else:
+            job_template = slurm_template.format(**job_args)
+
+            # Write the jobs file
+            with open(job_path, 'w') as job_file:
+                job_file.write(job_template)
+
+            # Submit the job
+            subprocess.call(["sbatch"] + args['qsub_arguments'].split() + [job_path])

--- a/scripts/avocado_featurize_submit
+++ b/scripts/avocado_featurize_submit
@@ -88,9 +88,9 @@ if __name__ == "__main__":
         '"[working_directory]/jobs/featurize_[dataset]/"'
     )
     parser.add_argument(
-        '--qsub_arguments',
+        '--extra_arguments',
         default='',
-        help='Additional arguments to pass to qsub'
+        help='Additional arguments to pass to qsub or sbatch'
     )
 
     raw_args = parser.parse_args()
@@ -130,7 +130,7 @@ if __name__ == "__main__":
                 job_file.write(job_template)
 
             # Submit the job
-            subprocess.call(["qsub"] + args['qsub_arguments'].split() + [job_path])
+            subprocess.call(["qsub"] + args['extra_arguments'].split() + [job_path])
         else:
             job_template = slurm_template.format(**job_args)
 
@@ -139,4 +139,4 @@ if __name__ == "__main__":
                 job_file.write(job_template)
 
             # Submit the job
-            subprocess.call(["sbatch"] + args['qsub_arguments'].split() + [job_path])
+            subprocess.call(["sbatch"] + args['extra_arguments'].split() + [job_path])


### PR DESCRIPTION
Currently `avocado` allows for distributed processing using the Sun Grid Engine, but it would also be desirable to be able to run on SLURM systems too.

This PR adds a `--schedular` flag for a user to request `"slurm"` with the template of the
`sbatch` form:
```
slurm_template = """#!/bin/bash
#SBATCH --export=ALL
#SBATCH -J {job_name}
#SBATCH -o {jobs_directory}/{job_name}.out
#SBATCH -e {jobs_directory}/{job_name}.err

# Use a single core for each job. This parallelizes better than trying to use
# multiple cores per job.
export MKL_NUM_THREADS=1
export NUMEXPR_NUM_THREADS=1
export OMP_NUM_THREADS=1

cd {working_directory}
avocado_featurize \\
    {dataset} \\
    --chunk {job} \\
    --num_chunks {num_jobs} \\
    --tag {tag}
"""
```
Where the conversion has been referenced from: https://srcc.stanford.edu/sge-slurm-conversion

This has been tested on a SLURM system to correctly featurize train and test sets via:
```
$ python avocado_featurize_submit plasticc_train --schedular='slurm'
$ python avocado_featurize_submit plasticc_test --num_jobs=500 --schedular='slurm' 
```

I have left this as a `[WIP]` for now as the code only checks whether a `--schedular` has been passed at all, and if not, the default SGE template is used, but I am not sure if this is the style you would prefer.